### PR TITLE
Refactor extract common config logic into trait

### DIFF
--- a/src/apache/config_file.rs
+++ b/src/apache/config_file.rs
@@ -10,7 +10,7 @@ impl ConfigFile {
 
     pub fn find_domain_in_str<S: AsRef<str>>(haystack: S, domain: &Domain) -> bool {
         fn inner(haystack: &str, domain: &Domain) -> bool {
-            let needle = format!("ServerName {domain}");
+            let needle = ConfigFile::server_name(domain);
 
 
             haystack
@@ -24,12 +24,16 @@ impl ConfigFile {
         inner(haystack.as_ref(), domain)
     }
 
+    fn server_name(domain: &Domain) -> String {
+        format!("ServerName {domain}")
+    }
+
     pub fn file_name(domain: &Domain) -> String {
         format!("{}.{}.conf", domain.get_name(), domain.get_tld())
     }
 
     fn file_path(domain: &Domain) -> PathBuf {
-        let mut base_path = Self::path();
+        let mut base_path = Self::sites_enabled_path();
 
         let file_name = Self::file_name(domain);
 
@@ -42,7 +46,7 @@ impl ConfigFile {
         Self::file_path(domain).with_extension("conf.bak")
     }
 
-    pub fn path() -> PathBuf {
+    pub fn sites_enabled_path() -> PathBuf {
         PathBuf::from(Self::SITES_AVAILABLE)
     }
 }

--- a/src/apache/config_file.rs
+++ b/src/apache/config_file.rs
@@ -1,55 +1,17 @@
 use std::path::PathBuf;
 
-use crate::domain::Domain;
+use crate::{domain::Domain, configuration_file::ConfigurationFile};
 
 pub struct ConfigFile;
 
-
-impl ConfigFile {
-    const SITES_AVAILABLE: &str = "/etc/apache/sites-available";
-
-    pub fn find_domain_in_str<S: AsRef<str>>(haystack: S, domain: &Domain) -> bool {
-        fn inner(haystack: &str, domain: &Domain) -> bool {
-            let needle = ConfigFile::server_name(domain);
-
-
-            haystack
-                .lines()
-                .map(str::trim)
-                .filter(|l| !l.contains('#'))
-                .any(|l| l.ends_with(&needle))
-        }
-        
-
-        inner(haystack.as_ref(), domain)
-    }
+impl<'a> ConfigurationFile<'a> for ConfigFile {
+    const SITES_AVAILABLE: &'a str = "/etc/apache/sites-available";
 
     fn server_name(domain: &Domain) -> String {
         format!("ServerName {domain}")
     }
-
-    pub fn file_name(domain: &Domain) -> String {
-        format!("{}.{}.conf", domain.get_name(), domain.get_tld())
-    }
-
-    fn file_path(domain: &Domain) -> PathBuf {
-        let mut base_path = Self::sites_enabled_path();
-
-        let file_name = Self::file_name(domain);
-
-        base_path.push(file_name);
-
-        base_path
-    }
-
-    fn backup_path(domain: &Domain) -> PathBuf {
-        Self::file_path(domain).with_extension("conf.bak")
-    }
-
-    pub fn sites_enabled_path() -> PathBuf {
-        PathBuf::from(Self::SITES_AVAILABLE)
-    }
 }
+
 
 #[cfg(test)]
 mod test {
@@ -58,6 +20,8 @@ mod test {
     use crate::domain::Domain;
 
     use crate::apache::config_file::ConfigFile;
+
+    use crate::configuration_file::ConfigurationFile;
 
     #[test]
     fn find_domain_without_subdomain_file() {

--- a/src/configuration_file.rs
+++ b/src/configuration_file.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+
+use crate::domain::Domain;
+
+pub(crate) trait ConfigurationFile {
+    const SITES_AVAILABLE: &'static str;
+
+    fn find_domain_in_str<S: AsRef<str>>(haystack: S, domain: &Domain) -> bool {
+        let needle = Self::server_name(domain);
+
+        let haystack = haystack.as_ref();
+
+        haystack
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.contains('#'))
+            .any(|l| l.ends_with(&needle))        
+    }
+
+    fn sites_enabled_path() -> PathBuf {
+        PathBuf::from(Self::SITES_AVAILABLE)
+    }
+
+    fn file_name(domain: &Domain) -> String {
+        format!("{}.{}.conf", domain.get_name(), domain.get_tld())
+    }
+
+    fn file_path(domain: &Domain) -> PathBuf {
+        let mut base_path = Self::sites_enabled_path();
+
+        let file_name = Self::file_name(domain);
+
+        base_path.push(file_name);
+
+        base_path
+    }
+
+    fn backup_path(domain: &Domain) -> PathBuf {
+        Self::file_path(domain).with_extension("conf.bak")
+    }
+
+    fn server_name(domain: &Domain) -> String;
+}

--- a/src/configuration_file.rs
+++ b/src/configuration_file.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use crate::domain::Domain;
 
-pub(crate) trait ConfigurationFile {
-    const SITES_AVAILABLE: &'static str;
+pub(crate) trait ConfigurationFile<'a> {
+    const SITES_AVAILABLE: &'a str;
 
     fn find_domain_in_str<S: AsRef<str>>(haystack: S, domain: &Domain) -> bool {
         let needle = Self::server_name(domain);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod domain;
 mod nginx;
 mod webroot;
 mod apache;
-
+mod configuration_file;
 use std::error::Error;
 
 use crate::nginx::configurator::Configurator;


### PR DESCRIPTION
This PR extracts into a trait the functions from Apache config file that are the same as Nginx's as well as implementing it for Apache::ConfigFile